### PR TITLE
BREAKING: `execa-extra` improvements

### DIFF
--- a/.changeset/great-horses-tickle.md
+++ b/.changeset/great-horses-tickle.md
@@ -7,5 +7,5 @@ BREAKING: `execa-extra` improvements
 - Renamed `execaCommand` to `$`
 - Removed `createExecaCommand` API
 - Introduced `$.sync` API
-- Improved template parsing and escaping logic
+- Improved template parsing and escaping logic (Thanks [@ehmicky](https://github.com/ehmicky))
 - Improved type inference

--- a/.changeset/great-horses-tickle.md
+++ b/.changeset/great-horses-tickle.md
@@ -1,0 +1,11 @@
+---
+'execa-extra': minor
+---
+
+BREAKING: `execa-extra` improvements
+
+- Renamed `execaCommand` to `$`
+- Removed `createExecaCommand` API
+- Introduced `$.sync` API
+- Improved template parsing and escaping logic
+- Improved type inference

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
       }
     },
     "hooks/use-websocket": {
-      "version": "0.0.0",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@aacc/babel-preset": "*",

--- a/packages/execa-extra/.eslintrc.js
+++ b/packages/execa-extra/.eslintrc.js
@@ -8,5 +8,5 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: 'tsconfig.eslint.json',
   },
-  ignorePatterns: ['node_modules', 'dist'],
+  ignorePatterns: ['node_modules', 'dist', 'playground.ts'],
 }

--- a/packages/execa-extra/README.md
+++ b/packages/execa-extra/README.md
@@ -11,12 +11,22 @@ npm install execa-extra
 
 ## Usage
 
-### Basic
+### `$` API
 
 ```js
-import { execaCommand } from 'execa-extra'
+import { $ } from 'execa-extra'
 
-const { stdout } = await execaCommand`echo 'Hello world'`
+const { stdout } = await $`echo 'Hello world'`
+
+console.log(stdout)
+```
+
+### `$.sync` API
+
+```js
+import { $ } from 'execa-extra'
+
+const { stdout } = $.sync`echo 'Hello world'`
 
 console.log(stdout)
 ```
@@ -24,40 +34,34 @@ console.log(stdout)
 ### With options
 
 ```js
-import { execaCommand } from 'execa-extra'
+import { $ } from 'execa-extra'
 
-await execaCommand({ stdio: 'inherit' })`echo 'Hello world'`
+await $({ stdio: 'inherit' })`echo 'Hello world'`
 ```
 
-> See the
-> [execaCommand](https://github.com/sindresorhus/execa#execacommandcommand-options)
-> documentation for details on the available options
+> See the [execa](https://github.com/sindresorhus/execa#options) documentation
+> for details on the available options
 
 ### With shell syntax
 
 ```js
-import { execaCommand } from 'execa-extra'
+import { $ } from 'execa-extra'
 
-await execaCommand({
-  stdio: 'inherit',
-  shell: true,
-})`echo 'Hello world' | wc -w`
+await $({ stdio: 'inherit', shell: true })`echo 'Hello world' | wc -w`
 ```
 
-> See the
-> [execaCommand](https://github.com/sindresorhus/execa#execacommandcommand-options)
-> documentation for details on the available options
+> See the [execa](https://github.com/sindresorhus/execa#options) documentation
+> for details on the available options
 
-### Create `execaCommand` API with pre-configured options
+### With pre-configured options
 
 ```js
-import { createExecaCommand } from 'execa-extra'
+import { $ } from 'execa-extra'
 
-const execaCommand = createExecaCommand({ stdio: 'inherit', shell: true })
+const my$ = $({ stdio: 'inherit', shell: true })
 
-await execaCommand`echo 'Hello world' | wc -w`
+await my$`echo 'Hello world' | wc -w`
 ```
 
-> See the
-> [execaCommand](https://github.com/sindresorhus/execa#execacommandcommand-options)
-> documentation for details on the available options
+> See the [execa](https://github.com/sindresorhus/execa#options) documentation
+> for details on the available options

--- a/packages/execa-extra/playground.ts
+++ b/packages/execa-extra/playground.ts
@@ -1,0 +1,35 @@
+import execa, { ExecaReturnValue, ExecaSyncReturnValue } from 'execa'
+
+import { $ } from './src/index'
+
+const a: ExecaReturnValue<string> = await $`ls`
+const b: ExecaReturnValue<string> = await execa.command('ls')
+
+const c: ExecaReturnValue<string> = await $({})`ls`
+const d: ExecaReturnValue<string> = await execa.command('ls', {})
+
+const e: ExecaReturnValue<string> = await $({ encoding: 'utf8' })`ls`
+const f: ExecaReturnValue<string> = await execa.command('ls', {
+  encoding: 'utf8',
+})
+
+const g: ExecaReturnValue<Buffer> = await $({ encoding: null })`ls`
+const h: ExecaReturnValue<Buffer> = await execa.command('ls', {
+  encoding: null,
+})
+
+const i: ExecaSyncReturnValue<string> = $.sync`ls`
+const j: ExecaSyncReturnValue<string> = execa.commandSync('ls')
+
+const k: ExecaSyncReturnValue<string> = $.sync({})`ls`
+const l: ExecaSyncReturnValue<string> = execa.commandSync('ls', {})
+
+const m: ExecaSyncReturnValue<string> = $.sync({ encoding: 'utf8' })`ls`
+const n: ExecaSyncReturnValue<string> = execa.commandSync('ls', {
+  encoding: 'utf8',
+})
+
+const o: ExecaSyncReturnValue<Buffer> = $.sync({ encoding: null })`ls`
+const p: ExecaSyncReturnValue<Buffer> = execa.commandSync('ls', {
+  encoding: null,
+})

--- a/packages/execa-extra/src/index.ts
+++ b/packages/execa-extra/src/index.ts
@@ -1,4 +1,4 @@
-import { command, Options, ExecaChildProcess } from 'execa'
+import execa, { Options, ExecaChildProcess, ExecaSyncReturnValue } from 'execa'
 
 const SPACES_REGEXP = / +/g
 


### PR DESCRIPTION
- Renamed `execaCommand` to `$`
- Removed `createExecaCommand` API
- Introduced `$.sync` API
- Improved template parsing and escaping logic (Thanks @ehmicky)
- Improved type inference

<img width="912" alt="Screen Shot 2023-01-14 at 12 09 11 PM" src="https://user-images.githubusercontent.com/32409546/212496742-15fa35b4-aac5-491d-b568-3d59d9ec5d5d.png">
